### PR TITLE
1 hertz flash

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2,28 +2,22 @@
 #include <stdint.h>
 
 #include "nrf_gpio.h"
+#include "nrfx_systick.h"
 
 #define INDICATOR_LED 20
-
-// only works with gcc `-O0` flag which disables all optimizations
-void bad_delay(void){
-    for(int i = 0; i < 1000000; i++){
-
-    }
-}
 
 int main(void)
 {
     nrf_gpio_cfg_output(INDICATOR_LED);
+    nrfx_systick_init();
 
     while (true)
     {
-        //turn off
+        //turn off (active low)
         nrf_gpio_pin_set(INDICATOR_LED);
-        bad_delay();
-        //turn on
+        nrfx_systick_delay_ms(500);
+        //turn on (active low)
         nrf_gpio_pin_clear(INDICATOR_LED);
-        bad_delay();
-
+        nrfx_systick_delay_ms(500);
     }
 }

--- a/src/makefile
+++ b/src/makefile
@@ -1,15 +1,16 @@
 TOOLCHAIN_BIN_DIR := /usr/local/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin
 CC := $(TOOLCHAIN_BIN_DIR)/arm-none-eabi-gcc
 
-INCLUDE_FLAGS := -I../lib/external/nrfx/hal/ \
-				 -I../lib/external/nrfx/ \
+INCLUDE_FLAGS := -I../lib/external/nrfx/ \
+				 -I../lib/external/nrfx/drivers/include \
+				 -I../lib/external/nrfx/hal/ \
 				 -I../lib/external/nrfx/templates \
 				 -I../lib/external/nrfx/mdk \
 				 -I../lib/external/CMSIS_5/CMSIS/Core/Include 
 ARCHITECTURE_FLAGS := -falign-functions=16 -fno-strict-aliasing -mcpu=cortex-m4 \
 					  -mfloat-abi=soft -msoft-float -mthumb
 override CC_FLAGS += -O0 -g -Wall $(ARCHITECTURE_FLAGS) $(INCLUDE_FLAGS) \
-					 -D NRF52805_XXAA -nostdlib
+					 -D NRF52805_XXAA -D NRFX_SYSTICK_ENABLED=1 -nostdlib
 CC_COMPILE_NO_LINK_FLAG = -c
 LD_FLAGS = -T nrf52805_xxaa.ld -nostdlib -Wl,-Map=memory.map
 
@@ -18,10 +19,13 @@ LD_FLAGS = -T nrf52805_xxaa.ld -nostdlib -Wl,-Map=memory.map
 blinky_app.bin: blinky_app.elf32-little
 	$(TOOLCHAIN_BIN_DIR)/arm-none-eabi-objcopy -I elf32-little -O binary $< $@
 
-blinky_app.elf32-little: main.o gcc_startup_nrf52805.o system_nrf52805.o
+blinky_app.elf32-little: main.o gcc_startup_nrf52805.o system_nrf52805.o nrfx_systick.o
 	$(CC) -o $@ $^ $(LD_FLAGS)
 
-main.o: main.c
+main.o: main.c nrfx_systick.o
+	$(CC) $(CC_FLAGS) $(CC_COMPILE_NO_LINK_FLAG) $<
+
+nrfx_systick.o: ../lib/external/nrfx/drivers/src/nrfx_systick.c
 	$(CC) $(CC_FLAGS) $(CC_COMPILE_NO_LINK_FLAG) $<
 
 system_nrf52805.o: ../lib/external/nrfx/mdk/system_nrf52805.c


### PR DESCRIPTION
Using the systick module:
- enabled the systick module with CC_FLAG passed definition (in
  makefile)
- replaced gross for-loop-based delays with robust systick timer delays.